### PR TITLE
Add support for Chromium as well

### DIFF
--- a/i3-chrome-tab-dragging.py
+++ b/i3-chrome-tab-dragging.py
@@ -10,12 +10,13 @@ last_new_window_title = ""
 # windows with these titles will never be converted to floating
 backlisted_window_titles = [
     "New Tab - Google Chrome",
+    "New Tab - Chromium",
 ]
 
 def on_window_new(i3, e): 
     global last_new_window_title
     
-    if e.container.window_class == "Google-chrome":
+    if e.container.window_class in ["Google-chrome", "Chromium-browser"]:
         # only switch to floating mode if the last window had the same name
         if last_new_window_title == e.container.window_title \
                 and e.container.window_title not in backlisted_window_titles:


### PR DESCRIPTION
Chromium (the open source version of Chrome) seems to use different window titles and classes. Thankfully, the fix is quite simple. I just added Chromium's new tab title to the blacklist and had the script check if the class is either Chrome's or Chromium's.

Really cool script by the way, I will certainly be using this! Thank you for your efforts!