### PR TITLE
Detect dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Description – What it does
 This script aims to solve a problem I have with dragging Chrome tabs while using
 the i3 window manager where it can be hard to place a second tab into another
-Chrome window. If it detects a Chrome window with the same title has been opened
-twice in a row (except for a "New Tab"), it switches the new window to floating
-mode so it can easily and independently be dragged to another Chrome window. This
-preserves the usual way of dragging a tab to another tile but also enables to
-get automatic floating mode if the window snaps to toe wrong place.
-
+Chrome window. If it detects a Chrome window has been opened while the user is
+dragging (left mouse button is being pressed down), it switches the new window to 
+floating mode so it can easily and independently be dragged to another Chrome window. 
+If the mouse is released without the window being droped in another chrome window,
+floating is toggled off, so the window will receive it's own new tile.
 
 # Installation
 - make sure all requirements are installed
@@ -29,19 +28,8 @@ With `i3-chrome-tab-dragging.py`:
 
 
 # Issues
-- I have no idea how I could detect a "tab dragging" before it opens a new i3
-  window.
-- After dragging the tab that has last been moved, it will instantly go to
-  floating mode.
-- The way this detects a "New Tab" from Chrome in a new window is based on the
-  title string. If this changes in a future (or past) version. This will break
-  and has to be expanded on.
-- Doesn't work for Firefox or other Browsers (feel free to open an PR if you
-  have a solution)
-- Should there be an option to float instantly?
-- aio?
-
-
+currently none
+ 
 # Contributing
 You are very welcome to contribute by PR or Issue to report wishes or bugs.
 Please honor PEP-8 if you open a PR, but don't worry if you don't know it, I

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 i3ipc
+pynput


### PR DESCRIPTION
Using pynput, mouse events can be read. 

I used that to keep track of the left mouse button. If a new Chromium window is detected, I check if the left mouse button is pressed down (= I am dragging) and only then make the window floating.

Also I had to change `Chromium-browser` to `Chromium`.

this works better for me than the "if same window created twice" logic from before.